### PR TITLE
bootstrap.sh modernization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .rvmrc
 chef-solo.log
 config.sh
+config.rb
+id_rsa_chef
+chef.key
 *.swp

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -4,6 +4,7 @@
 ##############################################################################
 
 . $(dirname $0)/config.sh
+. /etc/lsb-release
 
 # Utility functions
 msg() { echo " * $@"; }
@@ -13,8 +14,12 @@ safe() { "$@" || err "cannot $@"; }
 if [[ ! -f /usr/bin/chef-solo ]]; then
     msg "Installing chef"
     safe apt-get update
-    safe apt-get install -y ruby ruby1.8-dev build-essential wget \
-        libruby-extras libruby1.8-extras
+    if [[ $DISTRIB_RELEASE == "12.04" ]]; then
+        safe apt-get install -y ruby ruby1.8-dev build-essential wget
+    else
+        safe apt-get install -y ruby ruby1.8-dev build-essential wget \
+            libruby-extras libruby1.8-extras
+    fi
     safe wget http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz
     safe tar zxf rubygems-1.6.2.tgz
     pushd rubygems-1.6.2 > /dev/null


### PR DESCRIPTION
excluding more files in .gitignore
updating bootstrap.sh to deal with multiple versions of ubuntu (namely 10.04 and 12.04)
